### PR TITLE
Add colored warning when changelog has not been updated

### DIFF
--- a/rubin_changelog/output.py
+++ b/rubin_changelog/output.py
@@ -41,11 +41,24 @@ def print_changelog(changelog: Changelog, product_names: Set[str]):
     print("<html>")
     print("<head>")
     print("<title>Rubin Science Pipelines Changelog</title>")
-    print("</head>")
-    print("<body>")
-    print("<h1>Rubin Science Pipelines Changelog</h1>")
+    print("<style>.old-date {color: red;}</style>")
     gen_date = datetime.utcnow()
-    print(f"<p>Generated at {gen_date.strftime('%Y-%m-%d %H:%M +00:00')}.</p>")
+    print("<script>")
+    print("const MAX_DIFF = 1.0;")  # days
+    # Javascript may fail to parse date unless it exactly conforms to ISO
+    print(f"const TIMESTAMP = Date.parse('{gen_date.strftime('%Y-%m-%dT%H:%M:%SZ')}');")
+    print("function checkDate() {")
+    print("  const MS_PER_DAY = 24 * 3600 * 1000.0;")
+    print("  let load_time = Date.now();")
+    print("  if (load_time - TIMESTAMP > MAX_DIFF * MS_PER_DAY) {")
+    print("      document.getElementById('timestamp').className = 'old-date';")
+    print("  }")
+    print("}")
+    print("</script>")
+    print("</head>")
+    print("<body onload=\"checkDate();\">")
+    print("<h1>Rubin Science Pipelines Changelog</h1>")
+    print(f"<p id=\"timestamp\">Generated at {gen_date.strftime('%Y-%m-%d %H:%M +00:00')}.</p>")
 
     for tag, values in changelog.items():
         print_tag(tag, **values)

--- a/rubin_changelog/output.py
+++ b/rubin_changelog/output.py
@@ -39,7 +39,9 @@ def print_tag(
 
 def print_changelog(changelog: Changelog, product_names: Set[str]):
     print("<html>")
-    print("<head><title>Rubin Science Pipelines Changelog</title></head>")
+    print("<head>")
+    print("<title>Rubin Science Pipelines Changelog</title>")
+    print("</head>")
     print("<body>")
     print("<h1>Rubin Science Pipelines Changelog</h1>")
     gen_date = datetime.utcnow().strftime("%Y-%m-%d %H:%M +00:00")

--- a/rubin_changelog/output.py
+++ b/rubin_changelog/output.py
@@ -43,7 +43,7 @@ def print_changelog(changelog: Changelog, product_names: Set[str]):
     print("<body>")
     print("<h1>Rubin Science Pipelines Changelog</h1>")
     gen_date = datetime.utcnow().strftime("%Y-%m-%d %H:%M +00:00")
-    print("<p>Generated at {gen_date}.</p>")
+    print(f"<p>Generated at {gen_date}.</p>")
 
     for tag, values in changelog.items():
         print_tag(tag, **values)

--- a/rubin_changelog/output.py
+++ b/rubin_changelog/output.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Mapping, Set
 
 from .eups import EupsTag
@@ -42,7 +42,7 @@ def print_changelog(changelog: Changelog, product_names: Set[str]):
     print("<head>")
     print("<title>Rubin Science Pipelines Changelog</title>")
     print("<style>.old-date {color: red;}</style>")
-    gen_date = datetime.utcnow()
+    gen_date = datetime.now(timezone.utc)
     print("<script>")
     print("const MAX_DIFF = 1.0;")  # days
     # Javascript may fail to parse date unless it exactly conforms to ISO

--- a/rubin_changelog/output.py
+++ b/rubin_changelog/output.py
@@ -44,8 +44,8 @@ def print_changelog(changelog: Changelog, product_names: Set[str]):
     print("</head>")
     print("<body>")
     print("<h1>Rubin Science Pipelines Changelog</h1>")
-    gen_date = datetime.utcnow().strftime("%Y-%m-%d %H:%M +00:00")
-    print(f"<p>Generated at {gen_date}.</p>")
+    gen_date = datetime.utcnow()
+    print(f"<p>Generated at {gen_date.strftime('%Y-%m-%d %H:%M +00:00')}.</p>")
 
     for tag, values in changelog.items():
         print_tag(tag, **values)


### PR DESCRIPTION
This PR adds some Javascript that marks the timestamp red if it is older than a configurable threshold (currently, 24 hours). Views of the page with Javascript disabled are unaffected.

I've tested the new page both by manual inspection and by loading in Firefox and Edge.

Given the difficulty of writing code that writes other code, I'd recommend either that the Javascript be factored into its own file, or that the entire page be generated using a template rather than line-by-line. However, either option is best left to another PR.